### PR TITLE
Use error properties to give proper information

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -264,8 +264,8 @@ class Worker extends EventEmitter
     worker:    @name
     queue:     @queue
     payload:   job
-    exception: 'Error'
-    error:     err.toString()
+    exception: err.name
+    error:     err.message
     backtrace: err.stack.split('\n')[1...]
     failed_at: (new Date).toString()
 


### PR DESCRIPTION
The error object has a `name` and `message` properties.  While the default `name` is 'Error' a lot of packages set the `name` property to give more informative information. `Error` should not be a hard coded value.  The `message` property gives what `err.toString()` provides but without the redundant name.
