### PR TITLE
Fix #17, which allows resque-web to properly display workers

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -199,11 +199,9 @@ class Worker extends EventEmitter
   #
   # Returns nothing.
   pause: ->
-    @untrack()
     @procline "Sleeping for #{@conn.timeout/1000}s"
     setTimeout =>
       return if !@running
-      @track()
       @poll()
     , @conn.timeout
 


### PR DESCRIPTION
In reference to https://github.com/technoweenie/coffee-resque/issues/17

The problem is that when there is no work, or work is being completed too quickly, workers do not stay in the resque:workers set long enough to register in resque-web.  You can see this with logging--workers are continuously being added and removed from the set.  By removing the `track()` and `untrack()` calls in Worker,  workers can now be monitored as expected.  It also reduces the churn on Redis.

All tests pass, but I'm not sure if there was a specific reason it was handled this way.
