### PR TITLE
Register working job in redis

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -123,6 +123,7 @@ class Worker extends EventEmitter
     @running = false
     @untrack()
     @redis.del [
+      @conn.key('worker', @name)
       @conn.key('worker', @name, 'started')
       @conn.key('stat', 'failed', @name)
       @conn.key('stat', 'processed', @name)


### PR DESCRIPTION
This allows the job to show properly in resque-web
