### PR TITLE
Worker.end() does not delete all keys in redis

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -122,12 +122,7 @@ class Worker extends EventEmitter
   end: (cb) ->
     @running = false
     @untrack()
-    @redis.del [
-      @conn.key('worker', @name)
-      @conn.key('worker', @name, 'started')
-      @conn.key('stat', 'failed', @name)
-      @conn.key('stat', 'processed', @name)
-    ], cb
+    @redis.del @conn.key('worker', @name), @conn.key('worker', @name, 'started'), @conn.key('stat', 'failed', @name), @conn.key('stat', 'processed', @name), cb
 
   # PRIVATE METHODS
 


### PR DESCRIPTION
When I call `worker.end()` on a running worker, it does not delete all the associated keys in redis. The problem is that according to the [node redis library documentation](https://github.com/bnoguchi/redis-node#clientdelkey1-key2--keyn-callback), the way to delete multiple keys is

```
client.del(key1, key2, ..., keyn, callback)
```

But in coffee-resque, multiple keys are [passed as an array](https://github.com/technoweenie/coffee-resque/blob/master/src/index.coffee#L122) instead of [individual parameters](https://github.com/jasonbosco/coffee-resque/blob/master/src/index.coffee#L125).

Here's a trace from redis' `monitor` command when I call `worker.end()`: 

**Before applying my fix**

```
1351551290.814186 "srem" "resque:workers" "node:98309:temp"
1351551290.814216 "del" "resque:worker:node:98309:temp,resque:worker:node:98309:temp:started,resque:stat:failed:node:98309:temp,resque:stat:processed:node:98309:temp"
```

_Note how all the parameters passed as the first argument (as an array) are `join`ed together with a `,` and hence redis treats it as one long key._

**After applying my fix**

```
1351554029.511565 "srem" "resque:workers" "node:98400:temp"
1351554029.511627 "del" "resque:worker:node:98400:temp" "resque:worker:node:98400:temp:started" "resque:stat:failed:node:98400:temp" "resque:stat:processed:node:98400:temp"
```

_This successfully deletes all the keys_
