### PR TITLE
High CPU within the `process.title`

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -159,7 +159,7 @@ class Worker extends EventEmitter
   perform: (job) ->
     old_title = process.title
     @emit 'job', @, @queue, job
-    @procline "#{@queue} job since #{(new Date).toString()}"
+    #@procline "#{@queue} job since #{(new Date).toString()}"
     if cb = @callbacks[job.class]
       @workingOn job
       try
@@ -209,7 +209,7 @@ class Worker extends EventEmitter
   #
   # Returns nothing.
   pause: ->
-    @procline "Sleeping for #{@conn.timeout/1000}s"
+    #@procline "Sleeping for #{@conn.timeout/1000}s"
     setTimeout =>
       return if !@running
       @poll()


### PR DESCRIPTION
Consider the following code:

``` js
for (var i=0; i <= 256; i++) {
  worker = conn.worker('name', factory);
  worker.start();
}
```

When there is no data for one worker, one still invoke `poll` repeatedly, that means in one time, a process's title would be changed 256 times in this case, that might cause a high cpu process and an increasing memory usage. You can run this simple code for test in your machine, so I think sleep over these `procline` will be a good solution for this bug or hidden danger.
