### PR TITLE
added size method to coffee-resque to get number of jobs in queue.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -60,7 +60,7 @@ class Connection
   #
   # Returns nothing.
   size: (queue, callback) ->
-    @redis.llen this.key('queue', queue), callback
+    @redis.llen @key('queue', queue), callback
 
 
   # Public: Creates a single Worker from this Connection.

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -48,6 +48,21 @@ class Connection
       JSON.stringify(class: func, args: args || []),
       callback
 
+
+
+  # Public: Gets number of jobs in queue.
+  #
+  # queue     - String queue name.
+  # callback  - Callback with signature (err, response) to run when size is retrieved.
+  #             Err contains the error if there was an issue retrieving the size. If
+  #             there is no error, err will be null and response will contain the size
+  #             as an integer.
+  #
+  # Returns nothing.
+  size: (queue, callback) ->
+    @redis.llen this.key('queue', queue), callback
+
+
   # Public: Creates a single Worker from this Connection.
   #
   # queues    - Either a comma separated String or Array of queue names.

--- a/test/queue_size_test.coffee
+++ b/test/queue_size_test.coffee
@@ -1,0 +1,25 @@
+require './helper'
+conn  = resque()
+
+conn.size 'test', (err, resp)->
+  assert.equal err, null
+  initial_size = resp
+
+  conn.enqueue 'test',  'abc', ['one']
+  conn.enqueue 'test',  'abc', ['two']
+  conn.enqueue 'test',  'abc', ['three']
+  conn.enqueue 'test',  'abc', ['four']
+
+  conn.size 'test', (err, resp)->
+    assert.equal err, null
+    assert.equal resp, initial_size + 4
+    conn.end()
+
+process.on 'exit', ->
+  console.log '.'
+
+
+
+
+
+


### PR DESCRIPTION
Minor addition that allows you to asynchronously get the size of a queue. If you think this a good idea, but have any questions or concerns feel free to let me know. 

Example usage is:

resque.size( 'emails', function (err, count) {
    console.log( "number of jobs in emails is: " + count );
})