### PR TITLE
enqueue without a function inserts "undefined" into the queue

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -43,6 +43,8 @@ class Connection
   enqueue: (queue, func, args, callback) ->
     [callback, args] = [args, []] if typeof args is 'function'
 
+    if callback is undefined then callback = -> {}
+
     @redis.sadd  @key('queues'), queue
     @redis.rpush @key('queue', queue),
       JSON.stringify(class: func, args: args || []),

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -44,9 +44,8 @@ class Connection
     [callback, args] = [args, []] if typeof args is 'function'
 
     @redis.sadd  @key('queues'), queue
-    @redis.rpush @key('queue', queue),
-      JSON.stringify(class: func, args: args || []),
-      callback || -> {}
+    job = JSON.stringify(class: func, args: args || [])
+    @redis.rpush [@key('queue', queue), job], callback || ->
 
   # Public: Creates a single Worker from this Connection.
   #

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -43,12 +43,10 @@ class Connection
   enqueue: (queue, func, args, callback) ->
     [callback, args] = [args, []] if typeof args is 'function'
 
-    if callback is undefined then callback = -> {}
-
     @redis.sadd  @key('queues'), queue
     @redis.rpush @key('queue', queue),
       JSON.stringify(class: func, args: args || []),
-      callback
+      callback || -> {}
 
   # Public: Creates a single Worker from this Connection.
   #


### PR DESCRIPTION
Maybe I care about the error when inserting into the queue, maybe I don't.  I would expect the function to still be optional.

```
   resque.enqueue('math', 'add', [1,2])

 >  LRANGE 'resque:queue:math', 
 => [{"class":"add", "args": ["1", "2"]}, "undefined"]
```

It has to do with this code:

https://github.com/technoweenie/coffee-resque/blob/master/src/index.coffee#L47

which in coffee interprets that as an array instead of the callback function.  When your job processes the "undefined" job, you receive a JSON.parse error:  "Unexpected token u"
