### PR TITLE
Fix redis to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main"         : "./lib/index",
   "directories"  : {"lib"  : "./lib"},
   "repository"   : {"type" : "git",  "url": "https://github.com/technoweenie/coffee-resque.git"},
-  "dependencies" : {"redis": ">= 0.5.2"},
+  "dependencies" : {"redis": "1.0.0"},
   "engines"      : {"node" : ">= 0.2.6"},
   "scripts"      : {
     "postinstall": "echo Update Notes: Connection#enqueue now accepts an optional callback."


### PR DESCRIPTION
Version 2.0.0 of node-redis introduces breaking changes (see NodeRedis/node_redis#874). Until these changes are addressed, use version 1.0.0 of the client library.
